### PR TITLE
Add missing return type hints for test classes

### DIFF
--- a/tests/CreatableObject/CreatablePrivateConstructorObjectTest.php
+++ b/tests/CreatableObject/CreatablePrivateConstructorObjectTest.php
@@ -10,7 +10,7 @@ use NorseBlue\CreatableObjects\Tests\TestCase;
 class CreatablePrivateConstructorObjectTest extends TestCase
 {
     /** @test */
-    public function can_create_object_only_with_required_params()
+    public function can_create_object_only_with_required_params(): void
     {
         $subject = CreatablePrivateConstructorObject::create('value');
 
@@ -20,7 +20,7 @@ class CreatablePrivateConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_all_params()
+    public function can_create_object_with_all_params(): void
     {
         $subject = CreatablePrivateConstructorObject::create('value', 9);
 
@@ -30,7 +30,7 @@ class CreatablePrivateConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call()
+    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call(): void
     {
         $subject = CreatablePrivateConstructorObject::create('value', 9, 'extra param');
 
@@ -40,7 +40,7 @@ class CreatablePrivateConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function throws_exception_when_creating_with_missing_parameters()
+    public function throws_exception_when_creating_with_missing_parameters(): void
     {
         try {
             CreatablePrivateConstructorObject::create();

--- a/tests/CreatableObject/CreatablePrivateNoParamsConstructorObjectTest.php
+++ b/tests/CreatableObject/CreatablePrivateNoParamsConstructorObjectTest.php
@@ -8,7 +8,7 @@ use NorseBlue\CreatableObjects\Tests\TestCase;
 class CreatablePrivateNoParamsConstructorObjectTest extends TestCase
 {
     /** @test */
-    public function can_create_object()
+    public function can_create_object(): void
     {
         $subject = CreatablePrivateNoParamConstructorObject::create();
 
@@ -16,7 +16,7 @@ class CreatablePrivateNoParamsConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call()
+    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call(): void
     {
         $subject = CreatablePrivateNoParamConstructorObject::create('value', 9);
 

--- a/tests/CreatableObject/CreatableProtectedConstructorObjectTest.php
+++ b/tests/CreatableObject/CreatableProtectedConstructorObjectTest.php
@@ -10,7 +10,7 @@ use NorseBlue\CreatableObjects\Tests\TestCase;
 class CreatableProtectedConstructorObjectTest extends TestCase
 {
     /** @test */
-    public function can_create_object_only_with_required_params()
+    public function can_create_object_only_with_required_params(): void
     {
         $subject = CreatableProtectedConstructorObject::create('value');
 
@@ -20,7 +20,7 @@ class CreatableProtectedConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_all_params()
+    public function can_create_object_with_all_params(): void
     {
         $subject = CreatableProtectedConstructorObject::create('value', 9);
 
@@ -30,7 +30,7 @@ class CreatableProtectedConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call()
+    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call(): void
     {
         $subject = CreatableProtectedConstructorObject::create('value', 9, 'extra param');
 
@@ -40,7 +40,7 @@ class CreatableProtectedConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function throws_exception_when_creating_with_missing_parameters()
+    public function throws_exception_when_creating_with_missing_parameters(): void
     {
         try {
             CreatableProtectedConstructorObject::create();

--- a/tests/CreatableObject/CreatableProtectedNoParamsConstructorObjectTest.php
+++ b/tests/CreatableObject/CreatableProtectedNoParamsConstructorObjectTest.php
@@ -8,7 +8,7 @@ use NorseBlue\CreatableObjects\Tests\TestCase;
 class CreatableProtectedNoParamsConstructorObjectTest extends TestCase
 {
     /** @test */
-    public function can_create_object()
+    public function can_create_object(): void
     {
         $subject = CreatableProtectedNoParamConstructorObject::create();
 
@@ -16,7 +16,7 @@ class CreatableProtectedNoParamsConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call()
+    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call(): void
     {
         $subject = CreatableProtectedNoParamConstructorObject::create('value', 9);
 

--- a/tests/CreatableObject/CreatablePublicConstructorObjectTest.php
+++ b/tests/CreatableObject/CreatablePublicConstructorObjectTest.php
@@ -10,7 +10,7 @@ use NorseBlue\CreatableObjects\Tests\TestCase;
 class CreatablePublicConstructorObjectTest extends TestCase
 {
     /** @test */
-    public function can_create_object_only_with_required_params()
+    public function can_create_object_only_with_required_params(): void
     {
         $subject = CreatablePublicConstructorObject::create('value');
 
@@ -20,7 +20,7 @@ class CreatablePublicConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_all_params()
+    public function can_create_object_with_all_params(): void
     {
         $subject = CreatablePublicConstructorObject::create('value', 9);
 
@@ -30,7 +30,7 @@ class CreatablePublicConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call()
+    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call(): void
     {
         $subject = CreatablePublicConstructorObject::create('value', 9, 'extra param');
 
@@ -40,7 +40,7 @@ class CreatablePublicConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function throws_exception_when_creating_with_missing_parameters()
+    public function throws_exception_when_creating_with_missing_parameters(): void
     {
         try {
             CreatablePublicConstructorObject::create();

--- a/tests/CreatableObject/CreatablePublicNoParamsConstructorObjectTest.php
+++ b/tests/CreatableObject/CreatablePublicNoParamsConstructorObjectTest.php
@@ -8,7 +8,7 @@ use NorseBlue\CreatableObjects\Tests\TestCase;
 class CreatablePublicNoParamsConstructorObjectTest extends TestCase
 {
     /** @test */
-    public function can_create_object()
+    public function can_create_object(): void
     {
         $subject = CreatablePublicNoParamConstructorObject::create();
 
@@ -16,7 +16,7 @@ class CreatablePublicNoParamsConstructorObjectTest extends TestCase
     }
 
     /** @test */
-    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call()
+    public function can_create_object_with_extra_parameters_that_are_trimmed_from_call(): void
     {
         $subject = CreatablePublicNoParamConstructorObject::create('value', 9);
 

--- a/tests/CreatableObject/NoConstructorObjectTest.php
+++ b/tests/CreatableObject/NoConstructorObjectTest.php
@@ -10,7 +10,7 @@ use NorseBlue\CreatableObjects\Tests\TestCase;
 class NoConstructorObjectTest extends TestCase
 {
     /** @test */
-    public function bla()
+    public function bla(): void
     {
         try {
             $subject = NoConstructorObject::create();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Adding missed native type hints for classes on `tests` folder.

## How has this been tested?

- It has been tested currently.

## Screenshots (if appropriate)

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Enhancement work

## Checklist:

- [X] I have read the **[CONTRIBUTING](CONTRIBUTING.md)** document.
- [X] My pull request addresses exactly one patch/feature.
- [X] I have created a branch for this patch/feature.
- [X] Each individual commit in the pull request is meaningful.
- [X] I have added tests to cover my changes.
- [X] If my change requires a change to the documentation, I have updated it accordingly.